### PR TITLE
raspberry PI temperature is stored in node_thermal_zone_temp

### DIFF
--- a/node_exporter/1  Node Exporter for Prometheus Dashboard English Version  UPDATE 1102-1572704085938.json
+++ b/node_exporter/1  Node Exporter for Prometheus Dashboard English Version  UPDATE 1102-1572704085938.json
@@ -2121,7 +2121,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "node_hwmon_temp_celsius{instance=~'$node'}",
+          "expr": "node_hwmon_temp_celsius{instance=~'$node'} or node_thermal_zone_temp{instance=~'$node'}",
           "format": "time_series",
           "intervalFactor": 10,
           "legendFormat": "{{instance}}_{{chip}}_{{sensor}}",


### PR DESCRIPTION
slight tweak to the metric for the temperature panel in the bottom right so that it works on raspberry pi 3.